### PR TITLE
feat: introduce user and session data models

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,4 @@
+"""Umbra Security Service package."""
+from src.extensions import db
+
+__all__ = ["db"]

--- a/src/extensions.py
+++ b/src/extensions.py
@@ -1,0 +1,16 @@
+"""Application extensions.
+
+This module centralizes the initialization of extensions used across the
+application. It currently exposes a SQLAlchemy database instance that can be
+imported by any module that needs to interact with the persistence layer.
+"""
+from __future__ import annotations
+
+from flask_sqlalchemy import SQLAlchemy
+
+# Global SQLAlchemy database instance. Modules should import this rather than
+# instantiating their own `SQLAlchemy` object so that configuration performed in
+# ``create_app`` is consistently applied everywhere.
+db: SQLAlchemy = SQLAlchemy()
+
+__all__ = ["db"]

--- a/src/main.py
+++ b/src/main.py
@@ -1,36 +1,72 @@
-"""
-umbra-security-service - Service de sécurité, anti-triche et protection
-"""
+"""umbra-security-service - Service de sécurité, anti-triche et protection."""
+
 import os
+from typing import Optional
+
+from dotenv import load_dotenv
 from flask import Flask, jsonify
 from flask_cors import CORS
+from sqlalchemy.pool import StaticPool
+
+from src.extensions import db
+
+load_dotenv()
+
+
+def _str_to_bool(value: Optional[str], default: bool = False) -> bool:
+    """Convert an environment string to a boolean."""
+
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "y", "on"}
 
 
 def create_app() -> Flask:
     app = Flask(__name__)
     CORS(app)
-    
+
     # Configuration
-    app.config['DEBUG'] = os.getenv('FLASK_DEBUG', '0') == '1'
-    
-    # Health check endpoint
-    @app.route('/health')
-    def health():
-        return jsonify({
-            'success': True,
-            'data': {
-                'status': 'healthy',
-                'service': 'umbra-security-service'
+    app.config["DEBUG"] = _str_to_bool(os.getenv("FLASK_DEBUG"))
+
+    database_url = os.getenv("DATABASE_URL")
+    if database_url:
+        app.config["SQLALCHEMY_DATABASE_URI"] = database_url
+    else:
+        # Fall back to an in-memory SQLite database for local development and testing.
+        app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite+pysqlite:///:memory:"
+        app.config.setdefault(
+            "SQLALCHEMY_ENGINE_OPTIONS",
+            {
+                "connect_args": {"check_same_thread": False},
+                "poolclass": StaticPool,
             },
-            'message': 'Service en bonne santé'
-        }), 200
-    
+        )
+
+    app.config.setdefault("SQLALCHEMY_TRACK_MODIFICATIONS", False)
+    app.config["SQLALCHEMY_ECHO"] = _str_to_bool(os.getenv("SQLALCHEMY_ECHO"))
+
+    db.init_app(app)
+
+    # Health check endpoint
+    @app.route("/health")
+    def health():
+        return (
+            jsonify(
+                {
+                    "success": True,
+                    "data": {"status": "healthy", "service": "umbra-security-service"},
+                    "message": "Service en bonne santé",
+                }
+            ),
+            200,
+        )
+
     # TODO: Ajouter les routes spécifiques au service
-    
+
     return app
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     app = create_app()
-    port = int(os.getenv('PORT', '5006'))
-    app.run(host='0.0.0.0', port=port, debug=True)
+    port = int(os.getenv("PORT", "5006"))
+    app.run(host="0.0.0.0", port=port, debug=True)

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,0 +1,11 @@
+"""Database models for the Umbra security service."""
+from src.models.base import BaseModel, TimestampMixin
+from src.models.session import SessionToken
+from src.models.user import User
+
+__all__ = [
+    "BaseModel",
+    "TimestampMixin",
+    "User",
+    "SessionToken",
+]

--- a/src/models/base.py
+++ b/src/models/base.py
@@ -1,0 +1,48 @@
+"""Base models and mixins for SQLAlchemy models."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+from src.extensions import db
+
+
+def _utcnow() -> datetime:
+    """Return the current UTC datetime."""
+    return datetime.now(timezone.utc)
+
+
+class TimestampMixin:
+    """Mixin that adds timestamp columns to a model."""
+
+    created_at = db.Column(db.DateTime(timezone=True), default=_utcnow, nullable=False)
+    updated_at = db.Column(
+        db.DateTime(timezone=True), default=_utcnow, onupdate=_utcnow, nullable=False
+    )
+
+
+class BaseModel(db.Model, TimestampMixin):
+    """Base class for all models providing a UUID primary key."""
+
+    __abstract__ = True
+
+    id = db.Column(
+        db.String(36),
+        primary_key=True,
+        default=lambda: str(uuid.uuid4()),
+        nullable=False,
+        unique=True,
+    )
+
+    def as_dict(self) -> Dict[str, Any]:
+        """Return a serialisable representation of the model."""
+        return {
+            column.key: getattr(self, column.key) for column in self.__table__.columns
+        }
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__} id={self.id}>"
+
+
+__all__ = ["BaseModel", "TimestampMixin"]

--- a/src/models/session.py
+++ b/src/models/session.py
@@ -1,0 +1,76 @@
+"""Session token model definition."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, Index, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.models.base import BaseModel
+
+
+class SessionToken(BaseModel):
+    """Represents an authentication session associated with a user."""
+
+    __tablename__ = "session_tokens"
+
+    user_id: Mapped[str] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    access_token_hash: Mapped[str] = mapped_column(
+        String(128), nullable=False, unique=True
+    )
+    refresh_token_hash: Mapped[Optional[str]] = mapped_column(
+        String(128), nullable=True, unique=True
+    )
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    revoked_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
+    last_seen_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
+    ip_address: Mapped[Optional[str]] = mapped_column(String(45))
+    user_agent: Mapped[Optional[str]] = mapped_column(String(512))
+    is_persistent: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+
+    user: Mapped["User"] = relationship("User", back_populates="sessions")
+
+    __table_args__ = (Index("ix_session_tokens_user_active", "user_id", "expires_at"),)
+
+    @staticmethod
+    def _ensure_aware(moment: datetime | None) -> datetime | None:
+        if moment is None:
+            return None
+        if moment.tzinfo is None:
+            return moment.replace(tzinfo=timezone.utc)
+        return moment.astimezone(timezone.utc)
+
+    @property
+    def is_active(self) -> bool:
+        """Return ``True`` when the session is not expired nor revoked."""
+        if self.revoked_at is not None:
+            return False
+        expires_at = self._ensure_aware(self.expires_at)
+        if expires_at is None:
+            return False
+        return expires_at >= datetime.now(timezone.utc)
+
+    def revoke(self, when: Optional[datetime] = None) -> None:
+        """Mark the session as revoked."""
+        moment = when or datetime.now(timezone.utc)
+        self.revoked_at = self._ensure_aware(moment)
+
+    def touch(self, when: Optional[datetime] = None) -> None:
+        """Update the ``last_seen_at`` timestamp."""
+        moment = when or datetime.now(timezone.utc)
+        self.last_seen_at = self._ensure_aware(moment)
+
+    def __repr__(self) -> str:
+        return f"<SessionToken user_id={self.user_id!r}>"
+
+
+from src.models.user import User  # noqa: E402  (late import for relationship)
+
+__all__ = ["SessionToken"]

--- a/src/models/user.py
+++ b/src/models/user.py
@@ -1,0 +1,44 @@
+"""User model definition."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import Boolean, DateTime, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.models.base import BaseModel
+
+
+class User(BaseModel):
+    """Represents an authenticated user of the service."""
+
+    __tablename__ = "users"
+
+    email: Mapped[str] = mapped_column(
+        String(255), nullable=False, unique=True, index=True
+    )
+    username: Mapped[Optional[str]] = mapped_column(
+        String(80), nullable=True, unique=True, index=True
+    )
+    password_hash: Mapped[str] = mapped_column(String(255), nullable=False)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    is_verified: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    last_login_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
+
+    sessions: Mapped[list["SessionToken"]] = relationship(
+        "SessionToken",
+        back_populates="user",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
+
+    def __repr__(self) -> str:
+        return f"<User email={self.email!r}>"
+
+
+from src.models.session import (
+    SessionToken,
+)  # noqa: E402  (late import for relationship)
+
+__all__ = ["User"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
 import pytest
+
+from src.extensions import db
 from src.main import create_app
 
 
@@ -6,8 +8,13 @@ from src.main import create_app
 def app():
     """Create application for testing."""
     app = create_app()
-    app.config['TESTING'] = True
-    return app
+    app.config["TESTING"] = True
+
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
 
 
 @pytest.fixture

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -3,12 +3,12 @@
 
 def test_health_endpoint(client):
     """Test de l'endpoint /health."""
-    response = client.get('/health')
-    
+    response = client.get("/health")
+
     assert response.status_code == 200
-    
+
     data = response.get_json()
-    assert data['success'] is True
-    assert data['data']['status'] == 'healthy'
-    assert data['data']['service'] == 'umbra-security-service'
-    assert 'Service en bonne santé' in data['message']
+    assert data["success"] is True
+    assert data["data"]["status"] == "healthy"
+    assert data["data"]["service"] == "umbra-security-service"
+    assert "Service en bonne santé" in data["message"]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,97 @@
+"""Tests for the SQLAlchemy models."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import inspect
+
+from src.extensions import db
+from src.models import SessionToken, User
+
+
+def test_user_model_structure() -> None:
+    """The user model exposes the expected columns and relationships."""
+
+    mapper = inspect(User)
+
+    column_names = {column.key for column in mapper.columns}
+    expected_columns = {
+        "id",
+        "email",
+        "username",
+        "password_hash",
+        "is_active",
+        "is_verified",
+        "last_login_at",
+        "created_at",
+        "updated_at",
+    }
+    assert expected_columns.issubset(column_names)
+
+    email_column = mapper.columns["email"]
+    assert not email_column.nullable
+    assert email_column.unique
+
+    sessions_relationship = mapper.relationships["sessions"]
+    assert sessions_relationship.mapper.class_ is SessionToken
+
+
+def test_session_token_lifecycle(app) -> None:
+    """Sessions maintain lifecycle helpers for revocation and activity."""
+
+    with app.app_context():
+        user = User(email="alice@example.com", username="alice", password_hash="hashed")
+        session_token = SessionToken(
+            user=user,
+            access_token_hash="access-token-hash",
+            refresh_token_hash="refresh-token-hash",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+            ip_address="127.0.0.1",
+        )
+
+        db.session.add(session_token)
+        db.session.commit()
+
+        # Relationship integrity
+        assert session_token.user == user
+        assert session_token in user.sessions
+
+        # Active session before revocation
+        assert session_token.is_active
+
+        # Revoking the session sets the flag and makes it inactive
+        session_token.revoke()
+        assert session_token.revoked_at is not None
+        assert not session_token.is_active
+
+        # Touch updates last_seen_at timestamp
+        previous_last_seen = session_token.last_seen_at
+        session_token.touch()
+        assert session_token.last_seen_at is not None
+        assert session_token.last_seen_at != previous_last_seen
+
+        db.session.delete(session_token)
+        db.session.delete(user)
+        db.session.commit()
+
+
+def test_session_token_expiration(app) -> None:
+    """Expired sessions are considered inactive."""
+
+    with app.app_context():
+        user = User(email="bob@example.com", username="bobby", password_hash="hashed")
+        expired_session = SessionToken(
+            user=user,
+            access_token_hash="access-token-hash-expired",
+            refresh_token_hash="refresh-token-hash-expired",
+            expires_at=datetime.now(timezone.utc) - timedelta(minutes=5),
+        )
+
+        db.session.add(expired_session)
+        db.session.commit()
+
+        assert not expired_session.is_active
+
+        db.session.delete(expired_session)
+        db.session.delete(user)
+        db.session.commit()


### PR DESCRIPTION
## Summary
- add a shared SQLAlchemy extension and timestamped base model for persistence
- implement User and SessionToken entities with relationship helpers and timezone-safe utilities
- wire the database configuration into the Flask app and cover the models with new tests

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d1a62778f083329818ec86f17871aa