### PR TITLE
feat: implement authentication and anomaly detection endpoints

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -9,6 +9,7 @@ from flask_cors import CORS
 from sqlalchemy.pool import StaticPool
 
 from src.extensions import db
+from src.routes import anomalies_bp, auth_bp
 
 load_dotenv()
 
@@ -61,7 +62,9 @@ def create_app() -> Flask:
             200,
         )
 
-    # TODO: Ajouter les routes spécifiques au service
+    # Register service blueprints
+    app.register_blueprint(auth_bp)
+    app.register_blueprint(anomalies_bp)
 
     return app
 

--- a/src/routes/__init__.py
+++ b/src/routes/__init__.py
@@ -1,0 +1,11 @@
+"""Application route blueprints."""
+
+from __future__ import annotations
+
+__all__ = [
+    "auth_bp",
+    "anomalies_bp",
+]
+
+from .auth import auth_bp  # noqa: E402  (import after definition)
+from .anomalies import anomalies_bp  # noqa: E402

--- a/src/routes/anomalies.py
+++ b/src/routes/anomalies.py
@@ -1,0 +1,59 @@
+"""Anomaly detection routes."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+from flask import Blueprint, jsonify, request
+
+from src.services.anomaly import anomaly_detector
+
+anomalies_bp = Blueprint("anomalies", __name__, url_prefix="/anomalies")
+
+
+def _json_response(payload: Dict[str, Any], status_code: int):
+    return jsonify(payload), status_code
+
+
+@anomalies_bp.post("/detect")
+def detect_anomalies():
+    """Evaluate a player's metrics and determine if behaviour is suspicious."""
+
+    data = request.get_json(silent=True) or {}
+    player_id = data.get("player_id")
+    metrics = data.get("metrics")
+
+    if not isinstance(player_id, str) or not player_id.strip():
+        return _json_response(
+            {
+                "success": False,
+                "message": "Identifiant joueur manquant.",
+            },
+            400,
+        )
+
+    if not isinstance(metrics, dict) or not metrics:
+        return _json_response(
+            {
+                "success": False,
+                "message": "Aucune métrique fournie pour l'analyse.",
+            },
+            400,
+        )
+
+    result = anomaly_detector.evaluate(metrics)
+
+    return _json_response(
+        {
+            "success": True,
+            "message": "Analyse réalisée.",
+            "data": {
+                "player_id": player_id,
+                "evaluated_at": datetime.now(timezone.utc).isoformat(),
+                "is_suspicious": result.is_suspicious,
+                "risk_score": result.risk_score,
+                "reasons": result.reasons,
+            },
+        },
+        200,
+    )

--- a/src/routes/auth.py
+++ b/src/routes/auth.py
@@ -1,0 +1,209 @@
+"""Authentication and user session routes."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+from flask import Blueprint, jsonify, request
+
+from src.extensions import db
+from src.services.auth import (
+    InactiveUserError,
+    InvalidCredentialsError,
+    UserAlreadyExistsError,
+    create_user,
+    serialize_user,
+    start_session,
+    validate_token,
+    verify_credentials,
+)
+
+auth_bp = Blueprint("auth", __name__, url_prefix="/auth")
+
+
+def _json_response(payload: Dict[str, Any], status_code: int):
+    return jsonify(payload), status_code
+
+
+@auth_bp.post("/register")
+def register():
+    """Register a new user account and issue authentication tokens."""
+
+    data = request.get_json(silent=True) or {}
+    email = str(data.get("email", "")).strip()
+    password = data.get("password")
+    username = data.get("username")
+    remember_me = bool(data.get("remember_me", False))
+
+    if not email or not isinstance(password, str) or not password:
+        return _json_response(
+            {
+                "success": False,
+                "message": "Adresse e-mail et mot de passe requis.",
+            },
+            400,
+        )
+
+    try:
+        user = create_user(email=email, password=password, username=username)
+    except UserAlreadyExistsError:
+        return _json_response(
+            {
+                "success": False,
+                "message": "Un utilisateur avec ces identifiants existe déjà.",
+            },
+            409,
+        )
+    except ValueError as exc:  # Validation error
+        return _json_response(
+            {
+                "success": False,
+                "message": str(exc),
+            },
+            400,
+        )
+
+    tokens = start_session(
+        user=user,
+        ip_address=request.remote_addr,
+        user_agent=request.headers.get("User-Agent"),
+        persistent=remember_me,
+    )
+    user.last_login_at = datetime.now(timezone.utc)
+
+    db.session.commit()
+
+    return _json_response(
+        {
+            "success": True,
+            "message": "Inscription réussie.",
+            "data": {
+                "user": serialize_user(user),
+                "tokens": tokens,
+            },
+        },
+        201,
+    )
+
+
+@auth_bp.post("/login")
+def login():
+    """Authenticate an existing user and return fresh session tokens."""
+
+    data = request.get_json(silent=True) or {}
+    email = str(data.get("email", "")).strip()
+    password = data.get("password")
+    remember_me = bool(data.get("remember_me", False))
+
+    if not email or not isinstance(password, str) or not password:
+        return _json_response(
+            {
+                "success": False,
+                "message": "Adresse e-mail et mot de passe requis.",
+            },
+            400,
+        )
+
+    try:
+        user = verify_credentials(email=email, password=password)
+    except InvalidCredentialsError:
+        return _json_response(
+            {
+                "success": False,
+                "message": "Identifiants invalides.",
+            },
+            401,
+        )
+    except InactiveUserError:
+        return _json_response(
+            {
+                "success": False,
+                "message": "Compte désactivé.",
+            },
+            403,
+        )
+
+    tokens = start_session(
+        user=user,
+        ip_address=request.remote_addr,
+        user_agent=request.headers.get("User-Agent"),
+        persistent=remember_me,
+    )
+    user.last_login_at = datetime.now(timezone.utc)
+    db.session.commit()
+
+    return _json_response(
+        {
+            "success": True,
+            "message": "Connexion réussie.",
+            "data": {
+                "user": serialize_user(user),
+                "tokens": tokens,
+            },
+        },
+        200,
+    )
+
+
+@auth_bp.post("/validate")
+def validate():
+    """Validate an access or refresh token."""
+
+    data = request.get_json(silent=True) or {}
+    token = data.get("token")
+    token_type = str(data.get("token_type", "access")).strip().lower()
+
+    if not isinstance(token, str) or not token:
+        return _json_response(
+            {
+                "success": False,
+                "message": "Token manquant.",
+                "data": {"is_valid": False},
+            },
+            400,
+        )
+
+    try:
+        session_token = validate_token(token, token_type=token_type)
+    except ValueError as exc:
+        return _json_response(
+            {
+                "success": False,
+                "message": str(exc),
+                "data": {"is_valid": False},
+            },
+            400,
+        )
+
+    if session_token is None:
+        return _json_response(
+            {
+                "success": False,
+                "message": "Token invalide ou expiré.",
+                "data": {"is_valid": False},
+            },
+            401,
+        )
+
+    session_token.touch()
+    db.session.commit()
+
+    return _json_response(
+        {
+            "success": True,
+            "message": "Token valide.",
+            "data": {
+                "is_valid": True,
+                "user": serialize_user(session_token.user),
+                "session": {
+                    "id": session_token.id,
+                    "expires_at": session_token.expires_at.isoformat(),
+                    "last_seen_at": session_token.last_seen_at.isoformat()
+                    if session_token.last_seen_at
+                    else None,
+                    "is_persistent": session_token.is_persistent,
+                },
+            },
+        },
+        200,
+    )

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -1,0 +1,7 @@
+"""Service layer helpers for the security service."""
+from __future__ import annotations
+
+__all__ = [
+    "auth",
+    "anomaly",
+]

--- a/src/services/anomaly.py
+++ b/src/services/anomaly.py
@@ -1,0 +1,93 @@
+"""Simple anomaly detection utilities."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+
+@dataclass(frozen=True)
+class DetectionResult:
+    """Result returned by the anomaly detector."""
+
+    is_suspicious: bool
+    reasons: List[str]
+    risk_score: float
+
+
+class AnomalyDetector:
+    """Rule based anomaly detector for anti-cheat heuristics."""
+
+    def __init__(self) -> None:
+        self.thresholds: Dict[str, float] = {
+            "actions_per_minute": 280.0,
+            "kill_death_ratio": 6.0,
+            "headshot_ratio": 0.9,
+            "accuracy": 0.96,
+            "reaction_time_ms": 120.0,
+            "suspicious_reports": 3.0,
+            "speed_multiplier": 1.6,
+        }
+
+    def evaluate(self, metrics: Dict[str, float]) -> DetectionResult:
+        """Evaluate metrics and decide whether behaviour is suspicious."""
+
+        reasons: List[str] = []
+        score = 0.0
+
+        def _register(condition: bool, message: str, weight: float) -> None:
+            nonlocal score
+            if condition:
+                reasons.append(message)
+                score += weight
+
+        apm = float(metrics.get("actions_per_minute", 0))
+        _register(
+            apm >= self.thresholds["actions_per_minute"],
+            "Activité par minute anormalement élevée.",
+            0.3,
+        )
+
+        kdr = float(metrics.get("kill_death_ratio", 0))
+        _register(
+            kdr >= self.thresholds["kill_death_ratio"],
+            "Ratio éliminations/morts exceptionnellement élevé.",
+            0.25,
+        )
+
+        headshot_ratio = float(metrics.get("headshot_ratio", 0))
+        accuracy = float(metrics.get("accuracy", 0))
+        _register(
+            headshot_ratio >= self.thresholds["headshot_ratio"]
+            and accuracy >= self.thresholds["accuracy"],
+            "Précision et ratio de tirs critiques irréalistes.",
+            0.2,
+        )
+
+        reaction_time = float(metrics.get("reaction_time_ms", 9999))
+        _register(
+            reaction_time <= self.thresholds["reaction_time_ms"],
+            "Temps de réaction anormalement bas.",
+            0.1,
+        )
+
+        reports = float(metrics.get("suspicious_reports", 0))
+        _register(
+            reports >= self.thresholds["suspicious_reports"],
+            "Multiples signalements suspects reçus.",
+            0.15,
+        )
+
+        speed_multiplier = float(metrics.get("speed_multiplier", 1.0))
+        _register(
+            speed_multiplier >= self.thresholds["speed_multiplier"],
+            "Variations de vitesse incohérentes avec les règles du jeu.",
+            0.15,
+        )
+
+        score = min(score, 1.0)
+        return DetectionResult(is_suspicious=bool(reasons), reasons=reasons, risk_score=score)
+
+
+anomaly_detector = AnomalyDetector()
+
+__all__ = ["DetectionResult", "AnomalyDetector", "anomaly_detector"]

--- a/src/services/auth.py
+++ b/src/services/auth.py
@@ -1,0 +1,214 @@
+"""Authentication helpers."""
+from __future__ import annotations
+
+import hashlib
+import re
+import secrets
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Dict, Optional
+
+from sqlalchemy.exc import IntegrityError
+from werkzeug.security import check_password_hash, generate_password_hash
+
+from src.extensions import db
+from src.models.session import SessionToken
+from src.models.user import User
+
+_ACCESS_TOKEN_TTL = timedelta(hours=1)
+_PERSISTENT_TOKEN_TTL = timedelta(days=30)
+_EMAIL_REGEX = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+
+class AuthError(Exception):
+    """Base class for authentication related errors."""
+
+
+class UserAlreadyExistsError(AuthError):
+    """Raised when attempting to create a user that already exists."""
+
+
+class InvalidCredentialsError(AuthError):
+    """Raised when supplied credentials are invalid."""
+
+
+class InactiveUserError(AuthError):
+    """Raised when an inactive user tries to authenticate."""
+
+
+@dataclass(frozen=True)
+class TokenPair:
+    """Representation of issued tokens."""
+
+    access_token: str
+    refresh_token: str
+
+    def as_dict(self) -> Dict[str, str]:
+        return {
+            "access_token": self.access_token,
+            "refresh_token": self.refresh_token,
+        }
+
+
+def _normalize_email(email: str) -> str:
+    if not isinstance(email, str) or not email:
+        raise ValueError("Adresse e-mail invalide.")
+    cleaned = email.strip().lower()
+    if not cleaned or not _EMAIL_REGEX.match(cleaned):
+        raise ValueError("Adresse e-mail invalide.")
+    return cleaned
+
+
+def _normalize_username(username: Optional[str]) -> Optional[str]:
+    if username is None:
+        return None
+    if not isinstance(username, str):
+        raise ValueError("Nom d'utilisateur invalide.")
+    cleaned = username.strip().lower()
+    return cleaned or None
+
+
+def _hash_token(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def _generate_token(length: int = 32) -> str:
+    return secrets.token_urlsafe(length)
+
+
+def _issue_tokens(persistent: bool) -> TokenPair:
+    access_token = _generate_token(32)
+    refresh_token = _generate_token(48) if persistent else _generate_token(40)
+    return TokenPair(access_token=access_token, refresh_token=refresh_token)
+
+
+def create_user(*, email: str, password: str, username: Optional[str] = None) -> User:
+    """Create and return a new :class:`User` instance."""
+
+    normalized_email = _normalize_email(email)
+    if not isinstance(password, str) or len(password) < 8:
+        raise ValueError("Le mot de passe doit contenir au moins 8 caractères.")
+
+    normalized_username = _normalize_username(username)
+
+    user = User(
+        email=normalized_email,
+        username=normalized_username,
+        password_hash=generate_password_hash(password),
+    )
+
+    db.session.add(user)
+    try:
+        db.session.flush()
+    except IntegrityError as exc:
+        db.session.rollback()
+        raise UserAlreadyExistsError() from exc
+
+    return user
+
+
+def verify_credentials(*, email: str, password: str) -> User:
+    """Validate user credentials and return the user when valid."""
+
+    normalized_email = _normalize_email(email)
+    if not isinstance(password, str) or not password:
+        raise InvalidCredentialsError()
+
+    user = User.query.filter_by(email=normalized_email).first()
+    if user is None or not check_password_hash(user.password_hash, password):
+        raise InvalidCredentialsError()
+
+    if not user.is_active:
+        raise InactiveUserError()
+
+    return user
+
+
+def start_session(
+    *,
+    user: User,
+    ip_address: Optional[str] = None,
+    user_agent: Optional[str] = None,
+    persistent: bool = False,
+) -> Dict[str, str]:
+    """Create a new :class:`SessionToken` for a user."""
+
+    if user is None:
+        raise ValueError("Utilisateur manquant pour la création de session.")
+
+    tokens = _issue_tokens(persistent)
+    expires_in = _PERSISTENT_TOKEN_TTL if persistent else _ACCESS_TOKEN_TTL
+    expires_at = datetime.now(timezone.utc) + expires_in
+
+    session_token = SessionToken(
+        user=user,
+        access_token_hash=_hash_token(tokens.access_token),
+        refresh_token_hash=_hash_token(tokens.refresh_token),
+        expires_at=expires_at,
+        ip_address=ip_address,
+        user_agent=user_agent,
+        is_persistent=persistent,
+    )
+    session_token.touch()
+
+    db.session.add(session_token)
+
+    return tokens.as_dict()
+
+
+def serialize_user(user: User) -> Dict[str, Optional[str]]:
+    """Return a public representation of a user."""
+
+    def _serialize_datetime(value: Optional[datetime]) -> Optional[str]:
+        if value is None:
+            return None
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        else:
+            value = value.astimezone(timezone.utc)
+        return value.isoformat()
+
+    return {
+        "id": user.id,
+        "email": user.email,
+        "username": user.username,
+        "is_active": user.is_active,
+        "is_verified": user.is_verified,
+        "created_at": _serialize_datetime(user.created_at),
+        "updated_at": _serialize_datetime(user.updated_at),
+        "last_login_at": _serialize_datetime(user.last_login_at),
+    }
+
+
+def validate_token(token: str, *, token_type: str = "access") -> Optional[SessionToken]:
+    """Validate a token and return the associated :class:`SessionToken`."""
+
+    if token_type not in {"access", "refresh"}:
+        raise ValueError("Type de token inconnu.")
+
+    hashed = _hash_token(token)
+    if token_type == "access":
+        session_token = SessionToken.query.filter_by(access_token_hash=hashed).first()
+    else:
+        session_token = SessionToken.query.filter_by(refresh_token_hash=hashed).first()
+
+    if session_token is None or not session_token.is_active:
+        return None
+
+    if not session_token.user.is_active:
+        return None
+
+    return session_token
+
+
+__all__ = [
+    "AuthError",
+    "InactiveUserError",
+    "InvalidCredentialsError",
+    "UserAlreadyExistsError",
+    "create_user",
+    "serialize_user",
+    "start_session",
+    "validate_token",
+    "verify_credentials",
+]

--- a/tests/test_anomalies.py
+++ b/tests/test_anomalies.py
@@ -1,0 +1,54 @@
+"""Tests for anomaly detection endpoint."""
+from __future__ import annotations
+
+
+def test_anomaly_detection_flags_suspicious(client):
+    payload = {
+        "player_id": "player-123",
+        "metrics": {
+            "actions_per_minute": 400,
+            "kill_death_ratio": 10,
+            "headshot_ratio": 0.95,
+            "accuracy": 0.97,
+            "reaction_time_ms": 80,
+            "suspicious_reports": 5,
+            "speed_multiplier": 2.0,
+        },
+    }
+
+    response = client.post("/anomalies/detect", json=payload)
+    assert response.status_code == 200
+    data = response.get_json()["data"]
+    assert data["is_suspicious"] is True
+    assert data["risk_score"] > 0
+    assert len(data["reasons"]) >= 1
+
+
+def test_anomaly_detection_normal_behavior(client):
+    payload = {
+        "player_id": "player-456",
+        "metrics": {
+            "actions_per_minute": 120,
+            "kill_death_ratio": 1.2,
+            "headshot_ratio": 0.4,
+            "accuracy": 0.6,
+            "reaction_time_ms": 250,
+            "suspicious_reports": 0,
+            "speed_multiplier": 1.0,
+        },
+    }
+
+    response = client.post("/anomalies/detect", json=payload)
+    assert response.status_code == 200
+    data = response.get_json()["data"]
+    assert data["is_suspicious"] is False
+    assert data["risk_score"] == 0
+    assert data["reasons"] == []
+
+
+def test_anomaly_detection_requires_input(client):
+    response = client.post("/anomalies/detect", json={"player_id": ""})
+    assert response.status_code == 400
+
+    response = client.post("/anomalies/detect", json={"player_id": "abc"})
+    assert response.status_code == 400

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,111 @@
+"""Tests for authentication endpoints."""
+from __future__ import annotations
+
+from typing import Dict
+
+from src.extensions import db
+from src.models.session import SessionToken
+from src.models.user import User
+
+
+def _register(client, payload: Dict[str, str]):
+    return client.post("/auth/register", json=payload)
+
+
+def _login(client, payload: Dict[str, str]):
+    return client.post("/auth/login", json=payload)
+
+
+def test_register_creates_user_and_session(client):
+    payload = {
+        "email": "player@example.com",
+        "password": "StrongPass123",
+        "username": "PlayerOne",
+    }
+    response = _register(client, payload)
+    assert response.status_code == 201
+    body = response.get_json()
+    assert body["success"] is True
+    tokens = body["data"]["tokens"]
+    assert tokens["access_token"]
+    assert tokens["refresh_token"]
+
+    with client.application.app_context():
+        user = User.query.filter_by(email="player@example.com").one()
+        assert user.username == "playerone"
+        assert user.sessions  # session created
+
+
+def test_register_duplicate_email(client):
+    first = _register(
+        client,
+        {"email": "duplicate@example.com", "password": "StrongPass123"},
+    )
+    assert first.status_code == 201
+
+    duplicate = _register(
+        client,
+        {"email": "duplicate@example.com", "password": "StrongPass123"},
+    )
+    assert duplicate.status_code == 409
+
+
+def test_login_returns_new_tokens(client):
+    _register(
+        client,
+        {"email": "user@example.com", "password": "StrongPass123"},
+    )
+
+    response = _login(
+        client,
+        {"email": "user@example.com", "password": "StrongPass123"},
+    )
+    assert response.status_code == 200
+    data = response.get_json()["data"]
+    assert data["user"]["email"] == "user@example.com"
+    assert data["tokens"]["access_token"]
+
+    with client.application.app_context():
+        user = User.query.filter_by(email="user@example.com").one()
+        assert user.last_login_at is not None
+        assert db.session.query(SessionToken).filter_by(user_id=user.id).count() >= 2
+
+
+def test_login_invalid_password(client):
+    _register(
+        client,
+        {"email": "wrong@example.com", "password": "StrongPass123"},
+    )
+
+    response = _login(
+        client,
+        {"email": "wrong@example.com", "password": "invalid"},
+    )
+    assert response.status_code == 401
+
+
+def test_validate_token_success(client):
+    response = _register(
+        client,
+        {"email": "validate@example.com", "password": "StrongPass123"},
+    )
+    tokens = response.get_json()["data"]["tokens"]
+
+    validation = client.post(
+        "/auth/validate",
+        json={"token": tokens["access_token"], "token_type": "access"},
+    )
+    assert validation.status_code == 200
+    body = validation.get_json()
+    assert body["data"]["is_valid"] is True
+    assert body["data"]["user"]["email"] == "validate@example.com"
+
+
+def test_validate_token_invalid(client):
+    response = client.post(
+        "/auth/validate",
+        json={"token": "invalid", "token_type": "access"},
+    )
+    assert response.status_code == 401
+    body = response.get_json()
+    assert body["data"]["is_valid"] is False


### PR DESCRIPTION
## Summary
- add authentication blueprint with routes for registering, logging in and validating tokens backed by session storage
- implement reusable authentication utilities and anomaly detection service logic
- expose anomaly detection endpoint and add coverage for the new APIs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2739da634833298bc0da070dfa92e